### PR TITLE
Switch to using the ip command instead of ifconfig when the platform isn't Darwin

### DIFF
--- a/src/ip-manager.ts
+++ b/src/ip-manager.ts
@@ -134,9 +134,10 @@ export default class IPManager {
    * A base subnet string.
    */
   private getAvailableSubnet(): string {
+    const ifconfig_command = this.config.platform === 'darwin' ? 'ifconfig' : 'ip a'
     for (let i = 18; i <= 31; i++) {
       const subnet = '172.' + i + '.0'
-      const existing = execSync('sudo ifconfig | grep ' + subnet + ' | wc -l').toString().trim()
+      const existing = execSync('sudo ' + ifconfig_command + ' | grep ' + subnet + ' | wc -l').toString().trim()
       if (existing === '0') {
         return subnet
       }


### PR DESCRIPTION
Fixes #8, hopefully :smile: 

The only other place that `ifconfig` is used is in [createInterfaceAlias()](https://github.com/codeenigma/ce-dev/blob/f004020c02a38226b6480a369ea60c3315930f7b/src/ip-manager.ts#L93), and that's only for macOS, which still uses `ifconfig`.

I checked this on both my Debian 10 and macOS machines:

**Debian 10**

```
$ ~/projects                                                               [17:48:29] 
> $ ./ce-dev/bin/run create --template drupal8 --project testrun                                    
Creating private network...
0896ed3d8e74e5271701650cfc8e05a38a8af7b6a57d9608fd076b736304da59
Starting controller container...
Creating ce_dev_controller ... done
Ensure user UID match those on the host... done
Regenerate containers SSH key... done
Ensure file ownership... done
Generate/renew CA certificate for SSL... done
? Path for the project /home/galooph/projects/testrun
Generating project from template... Project testrun created at /home/galooph/projects/testrun
```

**macOS**

```
$ ⮀ ~/Sites ⮀ ./ce-dev/bin/run create --template drupal8 --project testrun
Creating private network...
Password:
99f02b10e9166f3754fdc448ea0d0df511096358b60288e65ea92be2cfd9b7a8
Starting controller container...
[+] Running 20/20
 ⠿ ce_dev_controller Pulled                                                                                      128.0s
   ⠿ 0bc3020d05f1 Pull complete                                                                                   22.8s
   ⠿ c392ff70f093 Pull complete                                                                                  103.1s
   ⠿ 8b763bc1c130 Pull complete                                                                                  104.9s
   ⠿ 3c93d856fa3d Pull complete                                                                                  105.0s
   ⠿ f17785474003 Pull complete                                                                                  105.1s
   ⠿ 6a04f33d0793 Pull complete                                                                                  105.1s
   ⠿ c6bcf9f8754e Pull complete                                                                                  105.3s
   ⠿ 46a4740da39e Pull complete                                                                                  105.4s
   ⠿ c3991a20e3dd Pull complete                                                                                  105.4s
   ⠿ c5fc48f3b110 Pull complete                                                                                  105.5s
   ⠿ 1d7b3785d732 Pull complete                                                                                  105.6s
   ⠿ 881c891f9417 Pull complete                                                                                  105.6s
   ⠿ d281b83253d1 Pull complete                                                                                  105.7s
   ⠿ bc918ed27f21 Pull complete                                                                                  105.8s
   ⠿ 471fb8cf95fa Pull complete                                                                                  105.9s
   ⠿ 3b8c7c8aac65 Pull complete                                                                                  121.3s
   ⠿ 1b849a684637 Pull complete                                                                                  121.6s
   ⠿ f7dd3718bece Pull complete                                                                                  121.6s
   ⠿ 146f7e6791e7 Pull complete                                                                                  126.1s
[+] Running 7/7
 ⠿ Network ce_dev_controller_default  Created                                                                      3.7s
 ⠿ Volume "ce_dev_nvm_node"           Created                                                                      0.0s
 ⠿ Volume "ce_dev_ssh"                Created                                                                      0.0s
 ⠿ Volume "ce_dev_mkcert"             Created                                                                      0.0s
 ⠿ Volume "ce_dev_apt_cache"          Created                                                                      0.0s
 ⠿ Volume "ce_dev_composer_cache"     Created                                                                      0.0s
 ⠿ Container ce_dev_controller        Started                                                                      2.8s
Ensure user UID match those on the host...
Ensure user UID match those on the host... done
Regenerate containers SSH key... done
Ensure file ownership... done
Generate/renew CA certificate for SSL... done
? Path for the project /Users/galooph/Sites/testrun
Generating project from template... Project testrun created at /Users/galooph/Sites/testrun
```

