### PR TITLE
Fix docker-compose v2 issue and re-release to include clamav role

### DIFF
--- a/RELEASE
+++ b/RELEASE
@@ -1,2 +1,2 @@
-1.1.17
-Release to repackage ce-dev to force d8 compatible drush version.
+1.1.18
+Release to repackage ce-dev to fix docker-compose v2 volumes issue and install clamav role.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ce-dev",
   "description": "Local Stack wrapper tool",
-  "version": "1.1.17",
+  "version": "1.1.18",
   "author": " @pm98zz-c",
   "bin": {
     "ce-dev": "./bin/run"

--- a/src/controller-manager.ts
+++ b/src/controller-manager.ts
@@ -245,6 +245,9 @@ export default class ControllerManager {
           volumes: [
             'ce_dev_ssh:/home/ce-dev/.ssh',
             'ce_dev_mkcert:/home/ce-dev/.local/share/mkcert',
+            'ce_dev_apt_cache:/var/cache/apt/archives',
+            'ce_dev_composer_cache:/home/ce-dev/.composer/cache',
+            'ce_dev_nvm_node:/home/ce-dev/.nvm/versions/node',
             '/sys/fs/cgroup:/sys/fs/cgroup:ro',
             this.config.cacheDir + ':/home/ce-dev/.ce-dev-cache',
           ],


### PR DESCRIPTION
Ensures external volumes are created when the controller container is spun up
Installs clamav module to the controller container (new release)