### PR TITLE
#CE-62820: Add support for composer '2.x' in Drupal 9 provision templ…

### DIFF
--- a/templates/drupal9/ce-dev/ansible/provision.yml.j2
+++ b/templates/drupal9/ce-dev/ansible/provision.yml.j2
@@ -40,6 +40,11 @@
           _env_type: dev
         fpm:
           _env_type: dev
+    # R62820: Add support for composer '2.x' for D9 projects.
+    - php_composer:
+        version: ''
+        version_branch: '--2'
+        keep_updated: true
     - xdebug:
         cli: true
     - lhci:


### PR DESCRIPTION
https://redmine.codeenigma.net/issues/62820

Added support for composer `2.x` in Drupal 9 provision template.