### PR TITLE
Fix setup on a Mac: use Docker Compose V2 with the new 'cgroup' parameter.

### DIFF
--- a/.github/workflows/ce-dev-build.yml
+++ b/.github/workflows/ce-dev-build.yml
@@ -37,7 +37,7 @@ jobs:
           mkdir -p ~/.config/ce-dev
           touch ~/.config/ce-dev/preferences-1.x.yml
           echo 'docker_bin: docker' > ~/.config/ce-dev/preferences-1.x.yml
-          echo 'docker_compose_bin: docker-compose' >> ~/.config/ce-dev/preferences-1.x.yml
+          echo 'docker_compose_bin: docker compose' >> ~/.config/ce-dev/preferences-1.x.yml
           echo 'mkcert_bin: mkcert' >> ~/.config/ce-dev/preferences-1.x.yml
       - name: Build and push Docker images
         run: |

--- a/docs/GettingStarted.md
+++ b/docs/GettingStarted.md
@@ -38,7 +38,7 @@ Next step is to start our containers.
 ce-dev start
 ```
 What happened is:
-- we called `docker-compose up`
+- we called `docker compose up`
 - ensured file permissions, ownership and uid/gid match between your user on the host and the 'ce-dev' user within the container
 - started Unison file synchronisation
 - updated the /etc/hosts file on your laptop

--- a/docs/UserConfig.md
+++ b/docs/UserConfig.md
@@ -3,7 +3,7 @@
 You can access a few global settings using `ce-dev config`.
 
 ## Binaries
-You can alter the commands called for 'docker', 'docker-compose' and 'mkcert'. This is mostly useful if you added your user to the 'docker' group on Linux and don't want to be prompted for your password. Or if you're doing funky stuff !
+You can alter the commands called for 'docker', 'docker compose' and 'mkcert'. This is mostly useful if you added your user to the 'docker' group on Linux and don't want to be prompted for your password. Or if you're doing funky stuff !
 
 ## SSH Username and Key
 Define the default username and private key to be used to be able to [SSH from containers to private resources](ssh), eg. cloning private repos or syncing environments back.

--- a/install.sh
+++ b/install.sh
@@ -14,7 +14,7 @@ if [ -n "$(which ce-dev)" ]; then
   fi
 fi
 echo "Checking for dependencies..."
-for BINARY in docker docker-compose mkcert; do
+for BINARY in docker mkcert; do
   if [ -z "$(which "$BINARY")" ]; then
     echo "Could not find $BINARY"
     echo "Ensure it is installed and in your \$PATH"

--- a/src/base-cmd-abstract.ts
+++ b/src/base-cmd-abstract.ts
@@ -34,7 +34,7 @@ export default abstract class BaseCmd extends Command {
    * @member
    * Docker-compose executable path.
    */
-  protected dockerComposeBin = 'docker-compose'
+  protected dockerComposeBin = 'docker compose'
 
   /**
    * @member
@@ -85,8 +85,8 @@ export default abstract class BaseCmd extends Command {
     docker_bin: this.config.platform === 'linux' ? 'sudo docker' : 'docker',
     docker_compose_bin:
       this.config.platform === 'linux' ?
-        'sudo docker-compose' :
-        'docker-compose',
+        'sudo docker compose' :
+        'docker compose',
     mkcert_bin: 'mkcert',
     ssh_user: process.env.USER as string,
     ssh_key: (process.env.HOME as string) + '/.ssh/id_rsa',

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -298,7 +298,7 @@ export default class InitCmd extends BaseCmd {
         if (!service.volumes) {
           service.volumes = []
         }
-        service.volumes.push('/sys/fs/cgroup:/sys/fs/cgroup:ro')
+        service.volumes.push('/sys/fs/cgroup:/sys/fs/cgroup:rw')
         service.volumes = [...new Set(service.volumes)]
         if (!service.cap_add) {
           service.cap_add = []

--- a/src/compose-config-service-interface.ts
+++ b/src/compose-config-service-interface.ts
@@ -6,6 +6,8 @@ import ComposeConfigServiceCeDev from './compose-config-service-ce-dev-interface
 export default interface ComposeConfigService {
   'container_name'?: string;
   'image'?: string;
+  'platform'?: string;
+  'cgroup'?: 'host' | 'private';
   'volumes'?: Array<string>;
   'expose'?: Array<string>;
   'ports'?: Array<string>;

--- a/src/controller-manager.ts
+++ b/src/controller-manager.ts
@@ -17,9 +17,9 @@ export default class ControllerManager {
 
   /**
    * @member
-   * Docker-compose executable path.
+   * Docker compose executable path.
    */
-  private readonly dockerComposeBin: string = 'docker-compose'
+  private readonly dockerComposeBin: string = 'docker compose'
 
   /**
    * @member
@@ -236,6 +236,8 @@ export default class ControllerManager {
         ce_dev_controller: {
           container_name: 'ce_dev_controller',
           image: 'codeenigma/ce-dev-controller-1.x:latest',
+          platform: 'linux/amd64',
+          cgroup: 'host',
           hostname: 'ce_dev_controller',
           networks: {
             ce_dev: {
@@ -248,7 +250,7 @@ export default class ControllerManager {
             'ce_dev_apt_cache:/var/cache/apt/archives',
             'ce_dev_composer_cache:/home/ce-dev/.composer/cache',
             'ce_dev_nvm_node:/home/ce-dev/.nvm/versions/node',
-            '/sys/fs/cgroup:/sys/fs/cgroup:ro',
+            '/sys/fs/cgroup:/sys/fs/cgroup:rw',
             this.config.cacheDir + ':/home/ce-dev/.ce-dev-cache',
           ],
         },

--- a/templates/blank/ce-dev/ce-dev.compose.prebuilt.yml.j2
+++ b/templates/blank/ce-dev/ce-dev.compose.prebuilt.yml.j2
@@ -11,6 +11,8 @@ x-ce_dev:
 services:
   {{ project_name }}:
     image: 'codeenigma/blank-blank:latest'
+    platform: linux/amd64
+    cgroup: host
     cap_add:
       - NET_ADMIN
     x-ce_dev:

--- a/templates/blank/ce-dev/ce-dev.compose.yml.j2
+++ b/templates/blank/ce-dev/ce-dev.compose.yml.j2
@@ -2,7 +2,7 @@ version: "3.7"
 x-ce_dev:
   registry: localhost:5000
   project_name: {{ project_name }}
-  provision: 
+  provision:
     - ce-dev/ansible/provision.yml
   deploy:
     - ce-dev/ansible/deploy.yml
@@ -11,6 +11,8 @@ x-ce_dev:
 services:
   {{ project_name }}:
     image: codeenigma/ce-dev-1.x:latest
+    platform: linux/amd64
+    cgroup: host
     cap_add:
       - NET_ADMIN
     x-ce_dev:

--- a/templates/drupal8/ce-dev/ce-dev.compose.prebuilt.yml.j2
+++ b/templates/drupal8/ce-dev/ce-dev.compose.prebuilt.yml.j2
@@ -12,6 +12,8 @@ x-ce_dev:
 services:
   web:
     image: 'codeenigma/drupal8-web:latest'
+    platform: linux/amd64
+    cgroup: host
     expose:
       - 443
       - 80
@@ -35,5 +37,6 @@ services:
       - NET_ADMIN
   db:
     image: 'codeenigma/drupal8-db:latest'
+    platform: linux/amd64
     environment:
       MYSQL_ROOT_PASSWORD: ce-dev

--- a/templates/drupal8/ce-dev/ce-dev.compose.yml.j2
+++ b/templates/drupal8/ce-dev/ce-dev.compose.yml.j2
@@ -12,6 +12,8 @@ x-ce_dev:
 services:
   web:
     image: codeenigma/ce-dev-1.x:latest
+    platform: linux/amd64
+    cgroup: host
     expose:
       - 443
       - 80

--- a/templates/drupal9/ce-dev/ce-dev.compose.prebuilt.yml.j2
+++ b/templates/drupal9/ce-dev/ce-dev.compose.prebuilt.yml.j2
@@ -12,6 +12,8 @@ x-ce_dev:
 services:
   web:
     image: 'codeenigma/drupal9-web:latest'
+    platform: linux/amd64
+    cgroup: host
     expose:
       - 443
       - 80
@@ -35,5 +37,6 @@ services:
       - NET_ADMIN
   db:
     image: 'codeenigma/drupal9-db:latest'
+    platform: linux/amd64
     environment:
       MYSQL_ROOT_PASSWORD: ce-dev

--- a/templates/drupal9/ce-dev/ce-dev.compose.yml.j2
+++ b/templates/drupal9/ce-dev/ce-dev.compose.yml.j2
@@ -12,6 +12,8 @@ x-ce_dev:
 services:
   web:
     image: codeenigma/ce-dev-1.x:latest
+    platform: linux/amd64
+    cgroup: host
     expose:
       - 443
       - 80

--- a/templates/localgov/ce-dev/ce-dev.compose.prebuilt.yml.j2
+++ b/templates/localgov/ce-dev/ce-dev.compose.prebuilt.yml.j2
@@ -12,6 +12,8 @@ x-ce_dev:
 services:
   web:
     image: 'codeenigma/drupal8-web:latest'
+    platform: linux/amd64
+    cgroup: host
     expose:
       - 443
       - 80
@@ -35,5 +37,6 @@ services:
       - NET_ADMIN
   db:
     image: 'codeenigma/drupal8-db:latest'
+    platform: linux/amd64
     environment:
       MYSQL_ROOT_PASSWORD: ce-dev

--- a/templates/localgov/ce-dev/ce-dev.compose.yml.j2
+++ b/templates/localgov/ce-dev/ce-dev.compose.yml.j2
@@ -12,6 +12,8 @@ x-ce_dev:
 services:
   web:
     image: codeenigma/ce-dev-1.x:latest
+    platform: linux/amd64
+    cgroup: host
     expose:
       - 443
       - 80


### PR DESCRIPTION
Warning, this needs proper testing!

It's against `1.x` (not `devel`), because that's what I used for setting up and making changes.

These are the changes that *seem* to mitigate `ce-dev` issues on my Apple silicon. Would be great if someone could test this on a Linux machine.