### PR TITLE
#120 – Fix docker ps --quiet and --format use MR 1.x

### DIFF
--- a/src/base-cmd-abstract.ts
+++ b/src/base-cmd-abstract.ts
@@ -272,7 +272,7 @@ export default abstract class BaseCmd extends Command {
         projectContainers.push(service.container_name as string)
       }
     }
-    const running = execSync(this.dockerBin + ' ps --quiet --format={{.Names}}').toString()
+    const running = execSync(this.dockerBin + ' ps --format={{.Names}}').toString()
     const runningContainers = running.split('\n').filter(item => {
       if (item.length === 0) {
         return false

--- a/src/commands/clean.ts
+++ b/src/commands/clean.ts
@@ -44,7 +44,7 @@ export default class CleanCmd extends BaseCmd {
    * Prompts for user.
    */
   private containerChoice(): Array<inquirer.Question> {
-    const containers = execSync(this.dockerBin + ' ps -a --quiet --format={{.Names}}').toString()
+    const containers = execSync(this.dockerBin + ' ps -a --format={{.Names}}').toString()
     const containerNames = containers.split('\n').filter(item => {
       return (item.length > 0)
     })


### PR DESCRIPTION
Fix for #120 

`docker ps` change, https://github.com/docker/cli/pull/3666, now outputs a warning if both `--format` *and* `--quiet` are passed in.

Removing `--quiet` allows the `--format` parameter to be accepted.