### PR TITLE
221: Improve the ce-dev shell command

### DIFF
--- a/src/commands/shell.ts
+++ b/src/commands/shell.ts
@@ -46,6 +46,12 @@ export default class ShellCmd extends BaseCmd {
         container = response.container
       }
     }
-    execSync(this.dockerBin + ' exec -it -u ce-dev -w /home/ce-dev ' + container + ' sudo su ce-dev || exit 0', {stdio: 'inherit'})
+    try {
+      execSync(this.dockerBin + ' exec ' + container + ' [ -d "/home/ce-dev/deploy/live.local" ]')
+      execSync(this.dockerBin + ' exec -it -u ce-dev -w /home/ce-dev/deploy/live.local ' + container + ' sudo su ce-dev || exit 0', {stdio: 'inherit'})
+    }
+    catch {
+      execSync(this.dockerBin + ' exec -it -u ce-dev -w /home/ce-dev ' + container + ' sudo su ce-dev || exit 0', {stdio: 'inherit'})
+    }
   }
 }


### PR DESCRIPTION
Running ce-dev shell now drops you into the root of the project, if it exists, instead of /home/ce-dev, and defaults to /home/ce-dev otherwise.

fixes #221